### PR TITLE
Add Trimming Support

### DIFF
--- a/MTGOSDK/MTGOSDK.ref.props
+++ b/MTGOSDK/MTGOSDK.ref.props
@@ -44,6 +44,15 @@
   </ItemGroup>
 
   <!--
+    Trim reference assemblies bundled with the MTGO package when publishing.
+    This is necessary to ensure that the reference assemblies are properly
+    internalized in the final package, and can again be trimmed by ILLink
+    when the package is used by a self-contained application.
+  -->
+  <Import Project="lib\ILLink\ILLink.targets"
+          Condition="'$(PublishTrimmed)' == 'true' And '$(UseRef)' == 'true'" />
+
+  <!--
     When building the SDK locally, we must use the full project paths to
     explicitly reference the build/buildTransitive assets when referencing
     the MTGOSDK.MSBuild project instead of the NuGet package.

--- a/MTGOSDK/lib/ILLink/ILLink.Descriptors.xml
+++ b/MTGOSDK/lib/ILLink/ILLink.Descriptors.xml
@@ -1,0 +1,8 @@
+<linker>
+  <assembly fullname="FlsClient">
+    <type fullname="FlsClient.Interface.IFlsClientSessionUser">
+      <property name="Id" />
+      <property name="Name" />
+    </type>
+  </assembly>
+</linker>

--- a/MTGOSDK/lib/ILLink/ILLink.Descriptors.xml
+++ b/MTGOSDK/lib/ILLink/ILLink.Descriptors.xml
@@ -1,8 +1,120 @@
 <linker>
-  <assembly fullname="FlsClient">
-    <type fullname="FlsClient.Interface.IFlsClientSessionUser">
-      <property name="Id" />
-      <property name="Name" />
-    </type>
+  <assembly fullname="Core">
+    <namespace fullname="Shiny.Chat">
+      <type fullname="IChatSessionViewModel">
+        <property name="Name" />
+        <property name="Channel" />
+        <method name="Activate" />
+        <method name="Close" />
+        <method name="Send" />
+      </type>
+    </namespace>
+    <namespace fullname="Shiny.Core.Interfaces">
+      <type fullname="IDialogService">
+        <method name="ShowModal" />
+      </type>
+    </namespace>
+  </assembly>
+  <assembly fullname="WotC.MtGO.Client.Model.Reference">
+    <namespace fullname="WotC.MtGO.Client.Model">
+      <type fullname="ISession">
+        <method name="LogOff" />
+        <method name="LogOn" />
+      </type>
+    </namespace>
+    <namespace fullname="WotC.MtGO.Client.Model.Chat">
+      <type name="IChannel">
+        <property name="Id" />
+        <property name="Name" />
+        <property name="ParentId" />
+        <property name="IsJoined" />
+        <property name="IsJoinedForGame" />
+        <property name="MessageLog" />
+        <property name="Users" />
+        <property name="UserCount" />
+        <property name="SubChannels" />
+      </type>
+      <type name="IChatChannel">
+        <property name="Title" />
+        <property name="CanSendMessage" />
+        <property name="Messages" />
+      </type>
+    </namespace>
+    <namespace fullname="WotC.MtGO.Client.Model.Collection">
+      <type fullname="IPlayFormat">
+        <property name="Name" />
+        <property name="Code" />
+        <property name="MinimumDeckSize" />
+        <property name="MaximumDeckSize" />
+        <property name="MaximumCopiesOfACardPerDeck" />
+        <property name="MaximumSideboardSize" />
+        <property name="LegalSetsByCode" />
+        <property name="BasicLandsForDeckbuilding" />
+        <property name="GameStructureEnum" />
+        <method name="IsLegal" />
+        <method name="IsCardRestricted" />
+        <method name="IsCardBanned" />
+        <method name="CheckDeckLegality" />
+        <method name="SetDeckLegality" />
+      </type>
+    </namespace>
+    <namespace fullname="WotC.MtGO.Client.Model.Play">
+      <type fullname="IPlayerEvent">
+        <property name="EventId" />
+        <property name="EventToken" />
+        <property name="IsCompleted" />
+        <property name="WasEventRemovedFromSystem" />
+        <property name="PlayFormat" />
+        <property name="MinutesPerPlayer" />
+        <property name="MinimumPlayers" />
+        <property name="MaximumPlayers" />
+        <property name="IsLocalUserJoined" />
+        <property name="IsLocalUserParticipant" />
+        <property name="IsLocalUserEliminated" />
+        <property name="Description" />
+        <property name="JoinedUsers" />
+        <property name="DeckUsedToJoin" />
+      </type>
+    </namespace>
+    <namespace fullname="WotC.MtGO.Client.Model.Play.Events">
+      <type fullname="GameEventArgs">
+        <property name="Game" />
+      </type>
+      <type fullname="MatchStatusEventArgs">
+        <property name="Match" />
+        <property name="OldStatus" />
+        <property name="NewStatus" />
+      </type>
+    </namespace>
+    <namespace fullname="WotC.MtGO.Client.Model.Play.Filters">
+      <type fullname="IFilterablePlayEvent">
+        <property name="PlayerEvent" />
+        <property name="EventId" />
+        <property name="EventToken" />
+        <property name="StartTime" />
+      </type>
+    </namespace>
+    <namespace fullname="WotC.MtGO.Client.Model.Play.ReplayGameEvent">
+      <type fullname="IReplayGameEvent">
+        <property name="ReplayState" />
+        <property name="HostGshServerId" />
+      </type>
+    </namespace>
+    <namespace fullname="WotC.MtGO.Client.Model.Play.Tournaments">
+      <type fullname="IGameStandingRecord">
+        <property name="Id" />
+        <property name="GameState" />
+        <property name="CompletedDuration" />
+        <property name="WinnerIds" />
+      </type>
+    </namespace>
+    <namespace fullname="WotC.MtGO.Client.Model.Settings">
+      <type fullname="IHistoricalMatch">
+        <property name="Opponents" />
+        <property name="GameWins" />
+        <property name="GameLosses" />
+        <property name="GameIds" />
+      </type>
+    </namespace>
   </assembly>
 </linker>

--- a/MTGOSDK/lib/ILLink/ILLink.props
+++ b/MTGOSDK/lib/ILLink/ILLink.props
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <!-- Link all assemblies -->
+    <ILLinkArgs>$(ILLinkArgs) --action link</ILLinkArgs>
+    <!-- Specify types and members to preserve -->
+    <ILLinkArgs>$(ILLinkArgs) -x $(MSBuildThisFileDirectory)ILLink.Descriptors.xml</ILLinkArgs>
+    <!-- Ignore all unresolved types and members -->
+    <ILLinkArgs>$(ILLinkArgs) --skip-unresolved true</ILLinkArgs>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == ''">
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == 'true'">
+    <!-- RequiresUnreferenceCodeAttribute method called -->
+    <NoWarn>$(NoWarn);IL2026</NoWarn>
+    <!-- Invalid use of DynamicallyAccessedMembersAttribute -->
+    <NoWarn>$(NoWarn);IL2041;IL2042;IL2043;IL2056</NoWarn>
+    <!-- Reference to removed attribute type -->
+    <NoWarn>$(NoWarn);IL2045</NoWarn>
+    <!-- RequiresUnreferencedCodeAttribute mismatch on virtual override -->
+    <NoWarn>$(NoWarn);IL2046</NoWarn>
+    <!-- COM marshalling warning -->
+    <NoWarn>$(NoWarn);IL2050</NoWarn>
+    <!-- Reflection intrinsics with unknown arguments -->
+    <NoWarn>$(NoWarn);
+      IL2032;IL2055;IL2057;IL2058;IL2059;IL2060;IL2061;IL2096
+    </NoWarn>
+    <!-- Unknown values passed to locations with DynamicallyAccessedMemberTypes -->
+    <NoWarn>$(NoWarn);IL2062;IL2063;IL2064;IL2065;IL2066</NoWarn>
+    <!-- Unsatisfied DynamicallyAccessedMembers requirements -->
+    <NoWarn>$(NoWarn);
+      IL2067;IL2068;IL2069;IL2070;IL2071;IL2072;IL2073;IL2074;IL2075;IL2076;
+      IL2077;IL2078;IL2079;IL2080;IL2081;IL2082;IL2083;IL2084;IL2085;IL2086;
+      IL2087;IL2088;IL2089;IL2090;IL2091
+    </NoWarn>
+    <!-- DynamicallyAccessedMembersAttribute mismatch on virtual override -->
+    <NoWarn>$(NoWarn);IL2092;IL2093;IL2094;IL2095</NoWarn>
+    <!-- DynamicallyAccessedMembersAttribute used on unsupported member -->
+    <NoWarn>$(NoWarn);IL2097;IL2098;IL2099</NoWarn>
+  </PropertyGroup>
+
+  <!--
+    When running from Desktop MSBuild, DOTNET_HOST_PATH is not set.
+    In this case, explicitly specify the path to the dotnet host.
+  -->
+  <PropertyGroup Condition=" '$(DOTNET_HOST_PATH)' == '' ">
+    <_DotNetHostDirectory>$(NetCoreRoot)</_DotNetHostDirectory>
+    <_DotNetHostFileName>dotnet</_DotNetHostFileName>
+    <_DotNetHostFileName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</_DotNetHostFileName>
+  </PropertyGroup>
+
+</Project>

--- a/MTGOSDK/lib/ILLink/ILLink.targets
+++ b/MTGOSDK/lib/ILLink/ILLink.targets
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="ILLink.props" />
+
+  <Target Name="ComputeILLinkProps">
+    <PropertyGroup>
+      <ILLinkOutputDir>$(IntermediateOutputPath)illink\</ILLinkOutputDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <_LinkInputAssemblies Include="@(IntermediateAssembly)" />
+      <_LinkInputAssemblies Include="%(ReferenceCopyLocalPaths.Identity)"
+                            Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == ''" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="TrimReferenceAssemblies"
+          AfterTargets="CoreCompile"
+          BeforeTargets="MergeReferenceAssemblies"
+          DependsOnTargets="ComputeILLinkProps">
+
+    <Delete Files="$(ILLinkOutputDir)**\*" />
+
+    <ILLink AssemblyPaths="@(_LinkInputAssemblies)"
+            ReferenceAssemblyPaths="@(ReferencePath)"
+            RootAssemblyNames="$(AssemblyName)"
+            OutputDirectory="$(ILLinkOutputDir)"
+            ExtraArgs="$(ILLinkArgs)"
+            ToolExe="$(_DotNetHostFileName)"
+            ToolPath="$(_DotNetHostDirectory)"
+            NoWarn="$(NoWarn)"
+            ContinueOnError="ErrorAndContinue" />
+
+    <Delete Files="$(OutputPath)*.pdb;
+                   $(OutputPath)*.dll" />
+    <Copy SourceFiles="$(MergeReferenceAssemblies)"
+          DestinationFolder="$(OutputPath)" />
+
+  </Target>
+
+  <Target Name="UpdateILLinkOutput"
+          AfterTargets="TrimReferenceAssemblies"
+          BeforeTargets="MergeReferenceAssemblies">
+    <ItemGroup>
+      <_LinkOutputAssemblies Include="$(ILLinkOutputDir)**\*" />
+      <_LinkOutputIntermediaryAssembly Include="@(IntermediateAssembly->'$(ILLinkOutputDir)%(Filename)%(Extension)')" />
+      <_LinkOutputAssemblies Remove="@(_LinkOutputIntermediaryAssembly)" />
+      <IntermediateAssembly Remove="@(IntermediateAssembly)" />
+      <IntermediateAssembly Include="@(_LinkOutputIntermediaryAssembly)" />
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
+      <ReferenceCopyLocalPaths Include="@(_LinkOutputAssemblies)" />
+    </ItemGroup>
+    <ItemGroup>
+      <FileWrites Include="@(_LinkOutputAssemblies);@(_LinkOutputIntermediaryAssembly)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/MTGOSDK/lib/ILRepack/ILRepack.targets
+++ b/MTGOSDK/lib/ILRepack/ILRepack.targets
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <Import Project="ILRepack.Config.props" />
 
   <!-- Merge the main assembly with any copied reference assemblies -->
@@ -22,6 +21,7 @@
       LibraryPath="$(OutputPath)"
       OutputFile="$(OutputPath)$(AssemblyName).dll"
       InputAssemblies="@(InputAssemblies)"
+      InternalizeAssembly="@(ReferenceAssemblies -> '%(Filename)')"
       NoRepackRes="true"
       DebugInfo="false"
       Parallel="true" />

--- a/MTGOSDK/lib/ILRepack/ILRepack.targets
+++ b/MTGOSDK/lib/ILRepack/ILRepack.targets
@@ -21,7 +21,6 @@
       LibraryPath="$(OutputPath)"
       OutputFile="$(OutputPath)$(AssemblyName).dll"
       InputAssemblies="@(InputAssemblies)"
-      InternalizeAssembly="@(ReferenceAssemblies -> '%(Filename)')"
       NoRepackRes="true"
       DebugInfo="false"
       Parallel="true" />

--- a/MTGOSDK/src/API/Chat/MessageLog.cs
+++ b/MTGOSDK/src/API/Chat/MessageLog.cs
@@ -39,7 +39,6 @@ public sealed class MessageLog(dynamic chatMessageLog)
   // IList<Message> wrapper properties
   //
 
-
   /// <summary>
   /// The number of messages in the channel's message history.
   /// </summary>

--- a/MTGOSDK/src/API/Client.cs
+++ b/MTGOSDK/src/API/Client.cs
@@ -91,12 +91,12 @@ public sealed class Client : DLRWrapper<ISession>, IDisposable
   {
     get
     {
-      // TODO: We cannot bind an interface type as structs are not yet supported.
-      var UserInfo_t = Unbind(s_flsClientSession.LoggedInUser);
-
       // Only fetch and update the current user if the user Id has changed.
-      if (UserInfo_t.Id != m_currentUser?.Id)
-        m_currentUser = new User(UserInfo_t.Id, UserInfo_t.Name);
+      int userId = s_flsClientSession.LoggedInUser.Id;
+      if (userId != m_currentUser?.Id) {
+        string username = s_flsClientSession.LoggedInUser.Name;
+        m_currentUser = new User(userId, username);
+      }
 
       return m_currentUser;
     }

--- a/third_party/ScubaDiver/lib/ILRepack/ILRepack.targets
+++ b/third_party/ScubaDiver/lib/ILRepack/ILRepack.targets
@@ -25,6 +25,7 @@
       LibraryPath="$(OutputPath)"
       OutputFile="$(SolutionDir)dist\$(ConfigurationName)\$(TargetAssembly)"
       InputAssemblies="@(InputAssemblies)"
+      Internalize="true"
       NoRepackRes="true"
       DebugInfo="false"
       Parallel="true" />


### PR DESCRIPTION
Adds a custom [ILLink](https://aka.ms/dotnet-illink/) pipeline for trimming reference assemblies embedded in the MTGOSDK assembly. We leverage the [ILLink MSBuild task](https://github.com/dotnet/runtime/tree/main/docs/tools/illink) to add a post-build target that trims these assemblies before ILRepack runs. This reduces the assembly size from 14.14 MB to 3.88 MB (~72.6%), and the total package size from 2.85 MB to 1.38 MB (~51.6%).

As this library leverages type proxying with the ProxyType and DLRWrapper classes, most API type usage can properly be detected and trimmed by ILLink. Some internal usage of type unbindings w/ DLRWrapper will need to be handled in a custom preserve list. However, this is a relatively small task despite being a reflection-heavy library.